### PR TITLE
Fix inputnorm

### DIFF
--- a/chrom-seek
+++ b/chrom-seek
@@ -12,17 +12,17 @@ DISCLAIMER:
         NIAID Collaborative Bioinformatics Resource (NCBR)
    National Institute of Allergy and Infectious Diseases (NIAID)
 This software/database is a "United  States Government Work" under
-the terms of the United  States Copyright Act.  It was written as 
+the terms of the United  States Copyright Act.  It was written as
 part of the author's official duties as a United States Government
 employee and thus cannot be copyrighted. This software is freely
 available to the public for use.
 Although all  reasonable  efforts have been taken  to ensure  the
 accuracy and reliability of the software and data, NCBR do not and
-cannot warrant the performance or results that may  be obtained by 
+cannot warrant the performance or results that may  be obtained by
 using this software or data. NCBR and NIH disclaim all warranties,
-express  or  implied,  including   warranties   of   performance, 
+express  or  implied,  including   warranties   of   performance,
 merchantability or fitness for any particular purpose.
-Please cite the author and NIH resources like the "Biowulf Cluster" 
+Please cite the author and NIH resources like the "Biowulf Cluster"
 in any work or product based on this material.
 USAGE:
   $ chrom-seek <command> [OPTIONS]

--- a/src/files.py
+++ b/src/files.py
@@ -252,7 +252,8 @@ def peakcalls(file, delim='\t'):
                     pass
 
             # Add ChIP, input pairs to dictionary
-            pairs[chip_sample] = input_sample
+            if input_sample:
+                pairs[chip_sample] = input_sample
             block[chip_sample] = block_info
 
     return pairs, groups, block

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -43,8 +43,8 @@ groups                          = list(groupdatawinput.keys())
 reps                            = True if len(groupswreps) > 0 else False
 uniq_inputs                     = list(sorted(set([v for v in chip2input.values() if v])))
 sampleswinput                   = [
-    chip_value for chip_value, input_id in chip2input.items() \
-    if chip_value != 'NA' and chip_value != ''
+    chip_sid for chip_sid, input_sid in chip2input.items() \
+    if chip_sid != 'NA' and chip_sid != ''
 ]
 inputnorm                       = [""] if len(sampleswinput) == 0 else ["", ".inputnorm"]
 UropaCats                       = ["protTSS", "prot", "protSEC", "genes"]

--- a/workflow/rules/peak_utils.smk
+++ b/workflow/rules/peak_utils.smk
@@ -35,7 +35,6 @@ rule inputnorm:
     input:
         chip                                = lambda wc: join(bw_dir, f"{wc.name}.Q5DD.RPGC.bw"),
         ctrl                                = lambda wc: join(bw_dir, f"{chip2input[wc.name]}.Q5DD.RPGC.bw") 
-                                                if wc.name in chip2input and chip2input[wc.name] else []
     output:
         join(bw_dir, "{name}.Q5DD.RPGC.inputnorm.bw")
     params:

--- a/workflow/scripts/grouping.py
+++ b/workflow/scripts/grouping.py
@@ -2,22 +2,23 @@
 # ~~~ Common helper functions for grouping of outputs
 from os.path import join
 
+
 # common functions related to sample grouping or group meta-information
 def group_samples_by_reps(groupdata, samples, chip2input):
     groupdatawinput = {}
     groupswreps = []
-    for group, chipsamples in groupdata.items() :
-        tmp = [ ]
+    for group, chipsamples in groupdata.items():
+        tmp = []
         if len(chipsamples) > 1:
             groupswreps.append(group)
-        for chip in chipsamples :
+        for chip in chipsamples:
             if chip in samples:
                 tmp.append(chip)
-                input = chip2input[chip]
-                if input != 'NA' and input != '':
+                input = chip2input.get(chip, "")
+                if input != "NA" and input != "":
                     tmp.append(input)
         if len(tmp) != 0:
-            groupdatawinput[group]=set(tmp)
+            groupdatawinput[group] = set(tmp)
     return groupdatawinput, groupswreps
 
 
@@ -31,30 +32,30 @@ def group_output_files(extensions, groupslist, inputnorm):
     Note: Inputnorm will only be included when there are input samples.
     """
     dtoolgroups, dtoolext = [], []
-    
+
     if len(inputnorm) == 2:
-            dtoolgroups.extend(["InputNorm"])
-            dtoolext.extend([extensions[1]])
-    
+        dtoolgroups.extend(["InputNorm"])
+        dtoolext.extend([extensions[1]])
+
     for group in groupslist:
-            dtoolgroups.extend([group] * 2)
-            dtoolext.extend([extensions[1], extensions[0]])
-    
+        dtoolgroups.extend([group] * 2)
+        dtoolext.extend([extensions[1], extensions[0]])
+
     if len(inputnorm) == 2:
-            dtoolgroups.extend(["InputNorm.prot"])
-            dtoolext.extend([extensions[1]])
-    
+        dtoolgroups.extend(["InputNorm.prot"])
+        dtoolext.extend([extensions[1]])
+
     for group in groupslist:
-            dtoolgroups.extend([group + ".prot"] * 2)
-            dtoolext.extend([extensions[1], extensions[0]])
-    
+        dtoolgroups.extend([group + ".prot"] * 2)
+        dtoolext.extend([extensions[1], extensions[0]])
+
     return dtoolgroups, dtoolext
 
 
 def get_peaktools(assay_type):
     tools = ["macsNarrow"]
-    if assay_type == "atac": 
-        tools.append("Genrich") 
+    if assay_type == "atac":
+        tools.append("Genrich")
     elif assay_type == "chip":
         tools.append("macsBroad")
         # turn sicer off for now
@@ -63,14 +64,14 @@ def get_peaktools(assay_type):
 
 
 def test_for_block(groupdata, contrast, blocks):
-    """ only want to run blocking on contrasts where all
-    individuals are on both sides of the contrast """
-    contrastBlock = [ ]
+    """only want to run blocking on contrasts where all
+    individuals are on both sides of the contrast"""
+    contrastBlock = []
     for con in contrast:
         group1 = con[0]
         group2 = con[1]
-        block1 = [ blocks[sample] for sample in groupdata[group1] ]
-        block2 = [ blocks[sample] for sample in groupdata[group2] ]
+        block1 = [blocks[sample] for sample in groupdata[group1]]
+        block2 = [blocks[sample] for sample in groupdata[group2]]
         if len(block1) == len(block2):
             if len(set(block1).intersection(block2)) == len(block1):
                 contrastBlock.append(con)


### PR DESCRIPTION
- processing peak call files and assigning samples to inputs had the potential to add samples with out inputs
   - added LYBL logic to the functions that provide that mapping
   - removed the "guardrail" null-checking at the `inputnorm` rule level
   
   resolve #56 