### PR TITLE
fix: add isTRUE check for up & down bed exports

### DIFF
--- a/bin/DiffBind_v2_Deseq2.Rmd
+++ b/bin/DiffBind_v2_Deseq2.Rmd
@@ -180,10 +180,20 @@ try(dba.plotHeatmap(DBAnalysisDeseq2,contrast=1,method = DBA_DESEQ2,correlations
 ## Top 500 or less differentially bound peaks 
 ```{r Deseq2Report}
 UpPeaks <- DBReportDeseq2[which(DBReportDeseq2$Fold > 0)]
-rtracklayer::export(UpPeaks, up_file)
+if ( isTRUE(UpPeaks) && nrow(UpPeaks) > 0 ) {
+   rtracklayer::export(UpPeaks, up_file)
+} else {
+   file.create(up_file)
+   cat("No **UP** regulated peaks found!", file = up_file, append = TRUE)
+}
 
 DownPeaks <- DBReportDeseq2[which(DBReportDeseq2$Fold < 0)]
-rtracklayer::export(DownPeaks, down_file)
+if ( isTRUE(DownPeaks) && nrow(DownPeaks) > 0 ) {
+   rtracklayer::export(DownPeaks, down_file)
+} else {
+   file.create(down_file)
+   cat("No **DOWN** regulated peaks found!", file = down_file, append = TRUE)
+}
 
 D2i <- length(DBReportDeseq2)
 i <- as.integer(min(c(500, as.integer(max(c(D2i, 1))))))

--- a/bin/DiffBind_v2_Deseq2_block.Rmd
+++ b/bin/DiffBind_v2_Deseq2_block.Rmd
@@ -146,10 +146,20 @@ DBAnalysisDeseq2 <- dba.analyze(DBdatacontrast, method = DBA_DESEQ2)
 DBReportDeseq2 <- dba.report(DBAnalysisDeseq2, method = DBA_DESEQ2_BLOCK)
 
 UpPeaks <- DBReportDeseq2[which(DBReportDeseq2$Fold > 0)]
-rtracklayer::export(UpPeaks, up_file)
+if ( isTRUE(UpPeaks) && nrow(UpPeaks) > 0 ) {
+   rtracklayer::export(UpPeaks, up_file)
+} else {
+   file.create(up_file)
+   cat("No **UP** regulated peaks found!", file = up_file, append = TRUE)
+}
 
 DownPeaks <- DBReportDeseq2[which(DBReportDeseq2$Fold < 0)]
-rtracklayer::export(DownPeaks, down_file)
+if ( isTRUE(DownPeaks) && nrow(DownPeaks) > 0 ) {
+   rtracklayer::export(DownPeaks, down_file)
+} else {
+   file.create(down_file)
+   cat("No **DOWN** regulated peaks found!", file = down_file, append = TRUE)
+}
 ```
 
 ## PCA

--- a/bin/DiffBind_v2_EdgeR.Rmd
+++ b/bin/DiffBind_v2_EdgeR.Rmd
@@ -177,10 +177,20 @@ try(dba.plotHeatmap(DBAnalysisEdgeR, contrast=1, method=DBA_EDGER, correlations=
 
 ```{r EdgeRReport}
 UpPeaks <- DBReportEdgeR[which(DBReportEdgeR$Fold > 0)]
-rtracklayer::export(UpPeaks, up_file)
+if ( isTRUE(UpPeaks) && nrow(UpPeaks) > 0 ) {
+   rtracklayer::export(UpPeaks, up_file)
+} else {
+   file.create(up_file)
+   cat("No **UP** regulated peaks found!", file = up_file, append = TRUE)
+}
 
 DownPeaks <- DBReportEdgeR[which(DBReportEdgeR$Fold < 0)]
-rtracklayer::export(DownPeaks, down_file)
+if ( isTRUE(DownPeaks) && nrow(DownPeaks) > 0 ) {
+   rtracklayer::export(DownPeaks, down_file)
+} else {
+   file.create(down_file)
+   cat("No **DOWN** regulated peaks found!", file = down_file, append = TRUE)
+}
 
 D2i <- length(DBReportEdgeR)
 i <- as.integer(min(c(500, as.integer(max(c(D2i, 1))))))

--- a/bin/DiffBind_v2_EdgeR_block.Rmd
+++ b/bin/DiffBind_v2_EdgeR_block.Rmd
@@ -147,10 +147,20 @@ DBAnalysisEdgeR <- dba.analyze(DBdatacontrast, method=DBA_EDGER)
 DBReportEdgeR <- dba.report(DBAnalysisEdgeR, method=DBA_EDGER_BLOCK)
 
 UpPeaks <- DBReportEdgeR[which(DBReportEdgeR$Fold > 0)]
-rtracklayer::export(UpPeaks, up_file)
+if ( isTRUE(UpPeaks) && nrow(UpPeaks) > 0 ) {
+   rtracklayer::export(UpPeaks, up_file)
+} else {
+   file.create(up_file)
+   cat("No **UP** regulated peaks found!", file = up_file, append = TRUE)
+}
 
 DownPeaks <- DBReportEdgeR[which(DBReportEdgeR$Fold < 0)]
-rtracklayer::export(DownPeaks, down_file)
+if ( isTRUE(DownPeaks) && nrow(DownPeaks) > 0 ) {
+   rtracklayer::export(DownPeaks, down_file)
+} else {
+   file.create(down_file)
+   cat("No **DOWN** regulated peaks found!", file = down_file, append = TRUE)
+}
 ```
 
 ## PCA


### PR DESCRIPTION
resolves the last issue for #101 

added isTRUE check to `rtracklayer::export` 

`UpPeaks` & `DownPeaks` can be `NULL` when no peaks exist, so check `nrows` and `isTRUE`, if no rows output dummy file with warning message.

please see `/data/NHLBI_IDSS/dev/chrom-seek/NIAID-1182` for testing output