### PR TITLE
fix: run snakevis.py with right params

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -37,6 +37,9 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/vis/bin:$PATH"
           NEW_VER=$(python .github/autorelease.py $PR_URL -t $GITHUB_TOKEN)
           echo -e "\n --- $NEW_VER --- \n"
-          python .github/sv/snakevis.py .github/sv/cfchip_norep_winput.json $GITHUB_WORKSPACE/upload
+          for f in .github/sv/configs/*.json; do
+              BN="${f%.*}"
+              python .github/sv/snakevis.py -c .github/sv/snakevis.json -s ${BN}.json -u $GITHUB_WORKSPACE/upload
+          done
           ls -al $GITHUB_WORKSPACE/upload
           gh release upload $NEW_VER $GITHUB_WORKSPACE/upload/* --clobber


### PR DESCRIPTION
2nd round fixing auto release

## Release notes

### MultiQC report revamp
- Update of multiQC version used to v1.32 via sif container
- Complete recreation of the multiQC yaml in references (changes include splitting modules, changing flow, and adding manual descriptions)
- Addition to multiQC report of: Encode QC metrics, interactive enhancer profile plots (when created), interactive Spearman correlation plot, interactive TSS profile plots
- Also includes a minor bug fix so that DiffBind_QC rules do not rerun every run of the pipeline
### Continuous Integration
- Adding multiple CI components to harden pipeline
  - check version
  - auto release
  - snakevis on release
  
## Release Options
- [ ] Major release (X.0.0)
- [x] Minor release (0.X.0)
- [ ] Patch release (0.0.X)
- [ ] Skip release